### PR TITLE
Remove reference to layout dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ Version 2.1.1 for Thymeleaf 2
 Version 3.y.z will be compatible with Thymeleaf 3
 
 
-Add the Layout dialect to your existing Thymeleaf template engine:
+Add the Spring Data dialect to your existing Thymeleaf template engine:
 
 ```java
-
 templateEngine.addDialect(new SpringDataDialect());		// This line adds the dialect to Thymeleaf
 ```
 


### PR DESCRIPTION
Had a look at the readme since it was mentioned on the Thymeleaf Twitter feed, noticed the readme mentioned the layout dialect, which I think was a little oversight :stuck_out_tongue: 
