### PR TITLE
Add SpEL support for sd:pagination-sort in PaginationSortAttrProcessor

### DIFF
--- a/src/main/java/org/thymeleaf/dialect/springdata/PaginationSortAttrProcessor.java
+++ b/src/main/java/org/thymeleaf/dialect/springdata/PaginationSortAttrProcessor.java
@@ -3,6 +3,7 @@ package org.thymeleaf.dialect.springdata;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 import org.thymeleaf.context.ITemplateContext;
+import org.thymeleaf.dialect.springdata.util.Expressions;
 import org.thymeleaf.dialect.springdata.util.PageUtils;
 import org.thymeleaf.dialect.springdata.util.Strings;
 import org.thymeleaf.engine.AttributeName;
@@ -25,7 +26,7 @@ final class PaginationSortAttrProcessor extends AbstractAttributeTagProcessor {
     protected void doProcess(ITemplateContext context, IProcessableElementTag tag, AttributeName attributeName,
             String attributeValue, IElementTagStructureHandler structureHandler) {
 
-        String attrValue = String.valueOf(attributeValue).trim();
+        String attrValue = String.valueOf(Expressions.evaluate(context, attributeValue)).trim();
         Page<?> page = PageUtils.findPage(context);
         String url = PageUtils.createSortUrl(context, attrValue);
 


### PR DESCRIPTION
To support partials with parameter variables for sorting and dynamic fields, sd:pagination-sort has to support SpEL expressions to evaluate variable value.