### PR TITLE
Add unidirectional sort functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,10 +113,5 @@
 			<artifactId>thymeleaf</artifactId>
 			<version>3.0.0.RELEASE</version>
 		</dependency>
-		<dependency>
-			<groupId>com.github.mnoky</groupId>
-			<artifactId>thymeleaf-spring-data-dialect</artifactId>
-			<version>v3.3.1</version>
-		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.mnoky</groupId>
 	<artifactId>thymeleaf-spring-data-dialect</artifactId>
-	<version>3.3.1.1</version>
+	<version>3.3.1.2</version>
 	
 	<name>Thymeleaf Spring Data Dialect</name>
 	<description>Data pagination made easy with Thymeleaf and Spring Data</description>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.0.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,18 @@
 			<artifactId>thymeleaf</artifactId>
 			<version>3.0.0.RELEASE</version>
 		</dependency>
+		<dependency>
+			<groupId>com.github.mnoky</groupId>
+			<artifactId>thymeleaf-spring-data-dialect</artifactId>
+			<version>master-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
+	
+	<repositories>
+		<repository>
+		    <id>jitpack.io</id>
+		    <url>https://jitpack.io</url>
+		</repository>
+	</repositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 					<target>1.6</target>
 				</configuration>
 			</plugin>
+			<!-- 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
@@ -72,7 +73,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<!-- 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.mnoky</groupId>
 	<artifactId>thymeleaf-spring-data-dialect</artifactId>
-	<version>3.3.1</version>
+	<version>3.3.1.1</version>
 	
 	<name>Thymeleaf Spring Data Dialect</name>
 	<description>Data pagination made easy with Thymeleaf and Spring Data</description>

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>io.github.jpenren</groupId>
+	<groupId>io.github.mnoky</groupId>
 	<artifactId>thymeleaf-spring-data-dialect</artifactId>
 	<version>3.3.1</version>
 	
 	<name>Thymeleaf Spring Data Dialect</name>
 	<description>Data pagination made easy with Thymeleaf and Spring Data</description>
-	<url>http://github.com/jpenren/thymeleaf-spring-data-dialect</url>
+	<url>http://github.com/mnoky/thymeleaf-spring-data-dialect</url>
 	<inceptionYear>2016</inceptionYear>
 
 	<licenses>
@@ -21,14 +21,14 @@
 		<developer>
 			<name>Javier Pena</name>
 			<email>javiprendo@gmail.com</email>
-			<organizationUrl>https://github.com/jpenren</organizationUrl>
+			<organizationUrl>https://github.com/mnoky</organizationUrl>
 		</developer>
 	</developers>
 
 	<scm>
-		<connection>scm:git:git://github.com/jpenren/thymeleaf-spring-data-dialect.git</connection>
-		<developerConnection>scm:git:git@github.com:jpenren/thymeleaf-spring-data-dialect.git</developerConnection>
-		<url>git@github.com:jpenren/thymeleaf-spring-data-dialect.git</url>
+		<connection>scm:git:git://github.com/mnoky/thymeleaf-spring-data-dialect.git</connection>
+		<developerConnection>scm:git:git@github.com:mnoky/thymeleaf-spring-data-dialect.git</developerConnection>
+		<url>git@github.com:mnoky/thymeleaf-spring-data-dialect.git</url>
 	</scm>
 
 	<properties>
@@ -49,6 +49,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
+				<version>3.0.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -87,6 +88,13 @@
 		</plugins>
 	</build>
 
+	<repositories>
+		<repository>
+		    <id>jitpack.io</id>
+		    <url>https://jitpack.io</url>
+		</repository>
+	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>javax.servlet</groupId>
@@ -110,12 +118,4 @@
 			<version>master-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
-	
-	<repositories>
-		<repository>
-		    <id>jitpack.io</id>
-		    <url>https://jitpack.io</url>
-		</repository>
-	</repositories>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 		<dependency>
 			<groupId>com.github.mnoky</groupId>
 			<artifactId>thymeleaf-spring-data-dialect</artifactId>
-			<version>master-SNAPSHOT</version>
+			<version>v3.3.1</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.mnoky</groupId>
 	<artifactId>thymeleaf-spring-data-dialect</artifactId>
-	<version>3.3.1.2</version>
+	<version>3.3.1.3</version>
 	
 	<name>Thymeleaf Spring Data Dialect</name>
 	<description>Data pagination made easy with Thymeleaf and Spring Data</description>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
@@ -86,6 +87,7 @@
 					</execution>
 				</executions>
 			</plugin>
+			-->
 		</plugins>
 	</build>
 

--- a/src/main/java/org/thymeleaf/dialect/springdata/PaginationSortAscAttrProcessor.java
+++ b/src/main/java/org/thymeleaf/dialect/springdata/PaginationSortAscAttrProcessor.java
@@ -2,15 +2,15 @@ package org.thymeleaf.dialect.springdata;
 
 import org.springframework.data.domain.Sort.Direction;
 
-final class PaginationSortAttrProcessor extends PaginationSortBaseAttrProcessor {
-    private static final String ATTR_NAME = "pagination-sort";
+final class PaginationSortAscAttrProcessor extends PaginationSortBaseAttrProcessor {
+    private static final String ATTR_NAME = "pagination-sort-asc";
     public static final int PRECEDENCE = 1000;
 
-    public PaginationSortAttrProcessor(final String dialectPrefix) {
+    public PaginationSortAscAttrProcessor(final String dialectPrefix) {
         super(dialectPrefix, ATTR_NAME, PRECEDENCE);
     }
     
     protected Direction getForcedDirection() {
-        return null;
+        return Direction.ASC;
     }
 }

--- a/src/main/java/org/thymeleaf/dialect/springdata/PaginationSortBaseAttrProcessor.java
+++ b/src/main/java/org/thymeleaf/dialect/springdata/PaginationSortBaseAttrProcessor.java
@@ -1,0 +1,48 @@
+package org.thymeleaf.dialect.springdata;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.thymeleaf.context.ITemplateContext;
+import org.thymeleaf.dialect.springdata.util.Expressions;
+import org.thymeleaf.dialect.springdata.util.PageUtils;
+import org.thymeleaf.dialect.springdata.util.Strings;
+import org.thymeleaf.engine.AttributeName;
+import org.thymeleaf.model.IProcessableElementTag;
+import org.thymeleaf.processor.element.AbstractAttributeTagProcessor;
+import org.thymeleaf.processor.element.IElementTagStructureHandler;
+import org.thymeleaf.templatemode.TemplateMode;
+
+import static org.thymeleaf.dialect.springdata.util.Strings.*;
+
+abstract class PaginationSortBaseAttrProcessor extends AbstractAttributeTagProcessor {
+    public PaginationSortBaseAttrProcessor(final String dialectPrefix, final String attrName, final int precedence) {
+        super(TemplateMode.HTML, dialectPrefix, null, false, attrName, true, precedence, true);
+    }
+
+    @Override
+    protected void doProcess(ITemplateContext context, IProcessableElementTag tag, AttributeName attributeName,
+            String attributeValue, IElementTagStructureHandler structureHandler) {
+
+        String attrValue = String.valueOf(Expressions.evaluate(context, attributeValue)).trim();
+        Page<?> page = PageUtils.findPage(context);
+        String url = PageUtils.createSortUrl(context, attrValue, getForcedDirection());
+
+        // Append class to the element if sorted by this field
+        Sort sort = page.getSort();
+        boolean isSorted = sort != null && sort.getOrderFor(attrValue) != null;
+        String clas = isSorted
+                ? SORTED_PREFIX.concat(sort.getOrderFor(attrValue).getDirection().toString().toLowerCase())
+                : EMPTY;
+
+        structureHandler.setAttribute(HREF, url);
+        String currentClass = tag.getAttributeValue(CLASS);
+        structureHandler.setAttribute(CLASS, Strings.concat(currentClass, BLANK, clas));
+    }
+    
+    /**
+     * Optional "forced" sort direction, if sorting in only one direction is allowed.
+     * @return null if sorting in either direction is allowed, otherwise specific direction
+     */
+    protected abstract Direction getForcedDirection();
+}

--- a/src/main/java/org/thymeleaf/dialect/springdata/PaginationSortDescAttrProcessor.java
+++ b/src/main/java/org/thymeleaf/dialect/springdata/PaginationSortDescAttrProcessor.java
@@ -2,15 +2,16 @@ package org.thymeleaf.dialect.springdata;
 
 import org.springframework.data.domain.Sort.Direction;
 
-final class PaginationSortAttrProcessor extends PaginationSortBaseAttrProcessor {
-    private static final String ATTR_NAME = "pagination-sort";
+final class PaginationSortDescAttrProcessor extends PaginationSortBaseAttrProcessor {
+    private static final String ATTR_NAME = "pagination-sort-desc";
     public static final int PRECEDENCE = 1000;
 
-    public PaginationSortAttrProcessor(final String dialectPrefix) {
+    public PaginationSortDescAttrProcessor(final String dialectPrefix) {
         super(dialectPrefix, ATTR_NAME, PRECEDENCE);
     }
     
     protected Direction getForcedDirection() {
-        return null;
+        return Direction.DESC;
     }
+
 }

--- a/src/main/java/org/thymeleaf/dialect/springdata/SpringDataDialect.java
+++ b/src/main/java/org/thymeleaf/dialect/springdata/SpringDataDialect.java
@@ -30,6 +30,8 @@ public final class SpringDataDialect implements IProcessorDialect {
         processors.add(new StandardXmlNsTagProcessor(TemplateMode.HTML, PREFIX));
         processors.add(new PaginationAttrProcessor(PREFIX));
         processors.add(new PaginationSortAttrProcessor(PREFIX));
+        processors.add(new PaginationSortAscAttrProcessor(PREFIX));
+        processors.add(new PaginationSortDescAttrProcessor(PREFIX));
         processors.add(new PaginationSummaryAttrProcessor(PREFIX));
         processors.add(new PageObjectAttrProcessor(PREFIX));
         processors.add(new PaginationUrlAttrProcessor(PREFIX));

--- a/src/main/java/org/thymeleaf/dialect/springdata/util/PageUtils.java
+++ b/src/main/java/org/thymeleaf/dialect/springdata/util/PageUtils.java
@@ -96,9 +96,10 @@ public final class PageUtils {
      * 
      * @param context execution context
      * @param fieldName field name to sort
+     * @param forcedDir optional, if specified then only this sort direction will be allowed
      * @return sort URL
      */
-    public static String createSortUrl(final ITemplateContext context, final String fieldName) {
+    public static String createSortUrl(final ITemplateContext context, final String fieldName, final Direction forcedDir) {
         // Params can be prefixed to manage multiple pagination on the same page
         final String prefix = getParamPrefix(context);
         final Collection<String> excludedParams = Arrays
@@ -109,7 +110,9 @@ public final class PageUtils {
         final Page<?> page = findPage(context);
         final Sort sort = page.getSort();
         final boolean hasPreviousOrder = sort != null && sort.getOrderFor(fieldName) != null;
-        if (hasPreviousOrder) {
+        if (forcedDir != null) {
+            sortParam.append(fieldName).append(COMMA).append(forcedDir.toString().toLowerCase());
+        } else if (hasPreviousOrder) {
             // Sort parameters exists for this field, modify direction
             Order previousOrder = sort.getOrderFor(fieldName);
             Direction dir = previousOrder.isAscending() ? Direction.DESC : Direction.ASC;


### PR DESCRIPTION
Add functionality for unidirectional sorts: "pagination-sort-asc" for ascending only sort and "pagination-sort-desc" for descending only sort. Add two new attribute processors: PaginationSortAscAttrProcessor and PaginationSortAscAttrProcessor which derive from a common base class PaginationSortBaseAttrProcessor. Most of the logic from PaginationSortAttrProcessor has been moved to this new common base class.

References: https://github.com/jpenren/thymeleaf-spring-data-dialect/issues/35