### PR TITLE
Added support for Bootstrap 5

### DIFF
--- a/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator.properties
+++ b/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator.properties
@@ -3,9 +3,9 @@ pagination=<ul class="{0}">{1}{2}{3}{4}{5}</ul>
 laquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&laquo;</span></span></li>
 laquo.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="First"><span aria-hidden="true">&laquo;</span></a></li>
 previous.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&lsaquo;</span></span></li>
-previous.page.link=<li><a class="page-link" href="{0}" aria-label="Previous"><span aria-hidden="true">&lsaquo;</span></a></li>
+previous.page.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="Previous"><span aria-hidden="true">&lsaquo;</span></a></li>
 link=<li class="page-item"><a class="page-link" href="{0}">{1}</a></li>
-link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only">(current)</span></span></li>
+link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only visually-hidden">(current)</span></span></li>
 next.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&rsaquo;</span></span></li>
 next.page.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="Next"><span aria-hidden="true">&rsaquo;</span></a></li>
 raquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&raquo;</span></span></li>

--- a/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_de.properties
+++ b/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_de.properties
@@ -5,7 +5,7 @@ laquo.link=<li class="page-item"><a href="{0}"class="page-link" aria-label="Erst
 previous.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&lsaquo;</span></span></li>
 previous.page.link=<li class="page-item"><a href="{0}"class="page-link" aria-label="Vorherige Seite"><span aria-hidden="true">&lsaquo;</span></a></li>
 link=<li class="page-item"><a class="page-link" href="{0}">{1}</a></li>
-link.active=<li class="active"><span class="page-link">{0}<span class="sr-only">(strom)</span></span></li>
+link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only visually-hidden">(strom)</span></span></li>
 next.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&rsaquo;</span></span></li>
 next.page.link=<li class="page-item"><a href="{0}"class="page-link" aria-label="Nächste Seite"><span aria-hidden="true">&rsaquo;</span></a></li>
 raquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&raquo;</span></span></li>

--- a/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_en.properties
+++ b/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_en.properties
@@ -3,9 +3,9 @@ pagination=<ul class="{0}">{1}{2}{3}{4}{5}</ul>
 laquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&laquo;</span></span></li>
 laquo.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="First"><span aria-hidden="true">&laquo;</span></a></li>
 previous.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&lsaquo;</span></span></li>
-previous.page.link=<li><a class="page-link" href="{0}" aria-label="Previous"><span aria-hidden="true">&lsaquo;</span></a></li>
+previous.page.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="Previous"><span aria-hidden="true">&lsaquo;</span></a></li>
 link=<li class="page-item"><a class="page-link" href="{0}">{1}</a></li>
-link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only">(current)</span></span></li>
+link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only visually-hidden">(current)</span></span></li>
 next.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&rsaquo;</span></span></li>
 next.page.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="Next"><span aria-hidden="true">&rsaquo;</span></a></li>
 raquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&raquo;</span></span></li>

--- a/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_es.properties
+++ b/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_es.properties
@@ -5,7 +5,7 @@ laquo.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Pri
 previous.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&lsaquo;</span></span></li>
 previous.page.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Anterior"><span aria-hidden="true">&lsaquo;</span></a></li>
 link=<li class="page-item"><a class="page-link" href="{0}">{1}</a></li>
-link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only">(actual)</span></span></li>
+link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only visually-hidden">(actual)</span></span></li>
 next.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&rsaquo;</span></span></li>
 next.page.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Siguiente"><span aria-hidden="true">&rsaquo;</span></a></li>
 raquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&raquo;</span></span></li>

--- a/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_fr.properties
+++ b/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_fr.properties
@@ -5,7 +5,7 @@ laquo.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Pre
 previous.page=<li class="diabled page-item"><span class="page-link"><span aria-hidden="true">&lsaquo;</span></span></li>
 previous.page.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Précédent"><span aria-hidden="true">&lsaquo;</span></a></li>
 link=<li class="page-item"><a class="page-link" href="{0}">{1}</a></li>
-link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only">(courant)</span></span></li>
+link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only visually-hidden">(courant)</span></span></li>
 next.page=<li class="diabled page-item"><span class="page-link"><span aria-hidden="true">&rsaquo;</span></span></li>
 next.page.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Prochain"><span aria-hidden="true">&rsaquo;</span></a></li>
 raquo=<li class="diabled page-item"><span class="page-link"><span aria-hidden="true">&raquo;</span></span></li>

--- a/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_gl.properties
+++ b/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_gl.properties
@@ -5,7 +5,7 @@ laquo.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Pri
 previous.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&lsaquo;</span></span></li>
 previous.page.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Anterior"><span aria-hidden="true">&lsaquo;</span></a></li>
 link=<li class="page-item"><a class="page-link" href="{0}">{1}</a></li>
-link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only">(actual)</span></span></li>
+link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only visually-hidden">(actual)</span></span></li>
 next.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&rsaquo;</span></span></li>
 next.page.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Seguinte"><span aria-hidden="true">&rsaquo;</span></a></li>
 raquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&raquo;</span></span></li>

--- a/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_it.properties
+++ b/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_it.properties
@@ -5,7 +5,7 @@ laquo.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Pri
 previous.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&lsaquo;</span></span></li>
 previous.page.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Precedente"><span aria-hidden="true">&lsaquo;</span></a></li>
 link=<li class="page-item"><a class="page-link" href="{0}">{1}</a></li>
-link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only">(corrente)</span></span></li>
+link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only visually-hidden">(corrente)</span></span></li>
 next.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&rsaquo;</span></span></li>
 next.page.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Prossimo"><span aria-hidden="true">&rsaquo;</span></a></li>
 raquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&raquo;</span></span></li>

--- a/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_nl.properties
+++ b/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_nl.properties
@@ -2,9 +2,9 @@ pagination=<ul class="{0}">{1}{2}{3}{4}{5}</ul>
 laquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&laquo;</span></span></li>
 laquo.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="Eerste"><span aria-hidden="true">&laquo;</span></a></li>
 previous.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&lsaquo;</span></span></li>
-previous.page.link=<li><a class="page-link" href="{0}" aria-label="Vorige"><span aria-hidden="true">&lsaquo;</span></a></li>
+previous.page.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="Vorige"><span aria-hidden="true">&lsaquo;</span></a></li>
 link=<li class="page-item"><a class="page-link" href="{0}">{1}</a></li>
-link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only">(huidige)</span></span></li>
+link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only visually-hidden">(huidige)</span></span></li>
 next.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&rsaquo;</span></span></li>
 next.page.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="Volgende"><span aria-hidden="true">&rsaquo;</span></a></li>
 raquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&raquo;</span></span></li>

--- a/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_pt.properties
+++ b/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_pt.properties
@@ -5,7 +5,7 @@ laquo.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Pri
 previous.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&lsaquo;</span></span></li>
 previous.page.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Anterior"><span aria-hidden="true">&lsaquo;</span></a></li>
 link=<li class="page-item"><a class="page-link" href="{0}">{1}</a></li>
-link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only">(atual)</span></span></li>
+link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only visually-hidden">(atual)</span></span></li>
 next.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&rsaquo;</span></span></li>
 next.page.link=<li class="page-item"><a href="{0}" class="page-link" aria-label="Próximo"><span aria-hidden="true">&rsaquo;</span></a></li>
 raquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&raquo;</span></span></li>

--- a/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_ru.properties
+++ b/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_ru.properties
@@ -5,7 +5,7 @@ laquo.link=<li class="page-item"><a href="{0}" aria-label="\u041f\u0435\u0440\u0
 previous.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&lsaquo;</span></span></li>
 previous.page.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="\u041f\u0440\u0435\u0434\u044b\u0434\u0443\u0449\u0430\u044f"><span aria-hidden="true">&lsaquo;</span></a></li>
 link=<li class="page-item"><a class="page-link" href="{0}">{1}</a></li>
-link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only">(current)</span></span></li>
+link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only visually-hidden">(current)</span></span></li>
 next.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&rsaquo;</span></span></li>
 next.page.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="\u0421\u043b\u0435\u0434\u0443\u044e\u0449\u0430\u044f"><span aria-hidden="true">&rsaquo;</span></a></li>
 raquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&raquo;</span></span></li>

--- a/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_zh_CN.properties
+++ b/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_zh_CN.properties
@@ -3,9 +3,9 @@ pagination=<ul class="{0}">{1}{2}{3}{4}{5}</ul>
 laquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&laquo;</span></span></li>
 laquo.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="\u9996\u9875"><span aria-hidden="true">&laquo;</span></a></li>
 previous.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&lsaquo;</span></span></li>
-previous.page.link=<li><a class="page-link" href="{0}" aria-label="\u4E0A\u9875"><span aria-hidden="true">&lsaquo;</span></a></li>
+previous.page.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="\u4E0A\u9875"><span aria-hidden="true">&lsaquo;</span></a></li>
 link=<li class="page-item"><a class="page-link" href="{0}">{1}</a></li>
-link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only">(current)</span></span></li>
+link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only visually-hidden">(current)</span></span></li>
 next.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&rsaquo;</span></span></li>
 next.page.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="\u4E0B\u9875"><span aria-hidden="true">&rsaquo;</span></a></li>
 raquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&raquo;</span></span></li>

--- a/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_zh_TW.properties
+++ b/src/main/resources/thymeleaf-spring-data-dialect/FullPaginationDecorator_zh_TW.properties
@@ -3,9 +3,9 @@ pagination=<ul class="{0}">{1}{2}{3}{4}{5}</ul>
 laquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&laquo;</span></span></li>
 laquo.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="\u9996\u9801"><span aria-hidden="true">&laquo;</span></a></li>
 previous.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&lsaquo;</span></span></li>
-previous.page.link=<li><a class="page-link" href="{0}" aria-label="\u4E0A\u9801"><span aria-hidden="true">&lsaquo;</span></a></li>
+previous.page.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="\u4E0A\u9801"><span aria-hidden="true">&lsaquo;</span></a></li>
 link=<li class="page-item"><a class="page-link" href="{0}">{1}</a></li>
-link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only">(current)</span></span></li>
+link.active=<li class="active page-item"><span class="page-link">{0}<span class="sr-only visually-hidden">(current)</span></span></li>
 next.page=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&rsaquo;</span></span></li>
 next.page.link=<li class="page-item"><a class="page-link" href="{0}" aria-label="\u4E0B\u9801"><span aria-hidden="true">&rsaquo;</span></a></li>
 raquo=<li class="disabled page-item"><span class="page-link"><span aria-hidden="true">&raquo;</span></span></li>


### PR DESCRIPTION
Added [CSS (visually-hidden)](https://getbootstrap.com/docs/5.1/getting-started/accessibility/#visually-hidden-content) for Bootstrap 5. Also, fixed some "page-item".

![page](https://user-images.githubusercontent.com/90756294/146403808-8d01c333-e2bb-4414-99cb-b9361c93b73a.png)
