### PR TITLE
Added support for async pagination via javascript

### DIFF
--- a/src/main/java/org/thymeleaf/dialect/springdata/Keys.java
+++ b/src/main/java/org/thymeleaf/dialect/springdata/Keys.java
@@ -4,6 +4,7 @@ public final class Keys {
 
     public static final String PAGE_VARIABLE_KEY = "_sd_.page.object";
     public static final String PAGINATION_URL_KEY = "_sd_.pagination.url";
+    public static final String PAGINATION_JS_FUNCTION_KEY = "_sd_.pagination.js.function";
     public static final String PAGINATION_QUALIFIER_PREFIX = "_sd_.pagination.qualifier.prefix";
     public static final String PAGE_EXPRESSION = "${page}";
     public static final String PAGINATION_SPLIT_KEY = "_sd_.pagination.split";

--- a/src/main/java/org/thymeleaf/dialect/springdata/PaginationAttrProcessor.java
+++ b/src/main/java/org/thymeleaf/dialect/springdata/PaginationAttrProcessor.java
@@ -22,7 +22,7 @@ final class PaginationAttrProcessor extends AbstractAttributeTagProcessor {
     protected void doProcess(ITemplateContext context, IProcessableElementTag tag, AttributeName attributeName,
             String attributeValue, IElementTagStructureHandler structureHandler) {
 
-        String attrValue = String.valueOf(attributeValue).trim();
+				String attrValue = String.valueOf(attributeValue).trim();
         PaginationDecorator decorator = PaginationDecoratorRegistry.getInstance().getDecorator(attrValue);
         String html = decorator.decorate(tag, context);
 

--- a/src/main/java/org/thymeleaf/dialect/springdata/PaginationJsFunctionAttrProcessor.java
+++ b/src/main/java/org/thymeleaf/dialect/springdata/PaginationJsFunctionAttrProcessor.java
@@ -1,0 +1,30 @@
+package org.thymeleaf.dialect.springdata;
+
+import org.thymeleaf.context.ITemplateContext;
+import org.thymeleaf.context.WebEngineContext;
+import org.thymeleaf.dialect.springdata.util.Expressions;
+import org.thymeleaf.engine.AttributeName;
+import org.thymeleaf.model.IProcessableElementTag;
+import org.thymeleaf.processor.element.AbstractAttributeTagProcessor;
+import org.thymeleaf.processor.element.IElementTagStructureHandler;
+import org.thymeleaf.templatemode.TemplateMode;
+
+final class PaginationJsFunctionAttrProcessor extends AbstractAttributeTagProcessor {
+    private static final String ATTR_NAME = "pagination-js-function";
+    public static final int PRECEDENCE = 900;
+
+    protected PaginationJsFunctionAttrProcessor(final String dialectPrefix) {
+        super(TemplateMode.HTML, dialectPrefix, null, false, ATTR_NAME, true, PRECEDENCE, true);
+    }
+
+    @Override
+    protected void doProcess(ITemplateContext context, IProcessableElementTag tag, AttributeName attributeName,
+            String attributeValue, IElementTagStructureHandler structureHandler) {
+
+        if (context instanceof WebEngineContext) {
+            Object url = Expressions.evaluate(context, attributeValue);
+            ((WebEngineContext) context).setVariable(Keys.PAGINATION_JS_FUNCTION_KEY, url);
+        }
+    }
+
+}

--- a/src/main/java/org/thymeleaf/dialect/springdata/SpringDataDialect.java
+++ b/src/main/java/org/thymeleaf/dialect/springdata/SpringDataDialect.java
@@ -35,6 +35,7 @@ public final class SpringDataDialect implements IProcessorDialect {
         processors.add(new PaginationSummaryAttrProcessor(PREFIX));
         processors.add(new PageObjectAttrProcessor(PREFIX));
         processors.add(new PaginationUrlAttrProcessor(PREFIX));
+        processors.add(new PaginationJsFunctionAttrProcessor(PREFIX));
         processors.add(new PaginationQualifierAttrProcessor(PREFIX));
         processors.add(new PaginationSplitAttrProcessor(PREFIX));
         processors.add(new PageSizeSelectorAttrProcessor(PREFIX));

--- a/src/main/java/org/thymeleaf/dialect/springdata/util/PageUtils.java
+++ b/src/main/java/org/thymeleaf/dialect/springdata/util/PageUtils.java
@@ -33,7 +33,6 @@ import org.thymeleaf.web.IWebRequest;
 import org.thymeleaf.web.servlet.IServletWebRequest;
 import org.unbescape.html.HtmlEscape;
 
-@SuppressWarnings("unchecked")
 public final class PageUtils {
 
     private PageUtils() {
@@ -84,6 +83,12 @@ public final class PageUtils {
     }
 
     public static String createPageUrl(final ITemplateContext context, int pageNumber) {
+
+	    	final String jsFunction = (String) context.getVariable(Keys.PAGINATION_JS_FUNCTION_KEY);
+	      if (jsFunction != null) {
+	      	return getJavaScriptURL(jsFunction, new StringBuilder().append(PAGE).append(EQ).append(pageNumber).toString());
+	      }
+
         final String prefix = getParamPrefix(context);
         final Collection<String> excludedParams = Arrays.asList(new String[] { prefix.concat(PAGE) });
         final String baseUrl = buildBaseUrl(context, excludedParams);
@@ -100,11 +105,6 @@ public final class PageUtils {
      * @return sort URL
      */
     public static String createSortUrl(final ITemplateContext context, final String fieldName, final Direction forcedDir) {
-        // Params can be prefixed to manage multiple pagination on the same page
-        final String prefix = getParamPrefix(context);
-        final Collection<String> excludedParams = Arrays
-                .asList(new String[] { prefix.concat(SORT), prefix.concat(PAGE) });
-        final String baseUrl = buildBaseUrl(context, excludedParams);
 
         final StringBuilder sortParam = new StringBuilder();
         final Page<?> page = findPage(context);
@@ -121,10 +121,27 @@ public final class PageUtils {
             sortParam.append(fieldName);
         }
 
+        final String jsFunction = (String) context.getVariable(Keys.PAGINATION_JS_FUNCTION_KEY);
+        if (jsFunction != null) {
+        	return getJavaScriptURL(jsFunction, new StringBuilder().append(SORT).append(EQ).append(sortParam).toString());
+        }
+
+        // Params can be prefixed to manage multiple pagination on the same page
+        final String prefix = getParamPrefix(context);
+        final Collection<String> excludedParams = Arrays
+                .asList(new String[] { prefix.concat(SORT), prefix.concat(PAGE) });
+        final String baseUrl = buildBaseUrl(context, excludedParams);
+
         return buildUrl(baseUrl, context).append(SORT).append(EQ).append(sortParam).toString();
     }
 
     public static String createPageSizeUrl(final ITemplateContext context, int pageSize) {
+
+	    	final String jsFunction = (String) context.getVariable(Keys.PAGINATION_JS_FUNCTION_KEY);
+	      if (jsFunction != null) {
+	      	return getJavaScriptURL(jsFunction, new StringBuilder().append(SIZE).append(EQ).append(pageSize).toString());
+	      }
+
         final String prefix = getParamPrefix(context);
         // Reset page number to avoid empty lists
         final Collection<String> excludedParams = Arrays
@@ -244,6 +261,25 @@ public final class PageUtils {
         final String prefix = (String) context.getVariable(Keys.PAGINATION_QUALIFIER_PREFIX);
 
         return prefix == null ? EMPTY : prefix.concat("_");
+    }
+
+    private static String getJavaScriptURL(String functionName, String params) {
+    		return Strings.concat(
+    				Strings.JAVASCRIPT_VOID_0,
+    				Strings.DOUBLE_QUOTE,
+    				Strings.BLANK,
+    				Strings.ONCLICK,
+    				Strings.EQ,
+    				Strings.DOUBLE_QUOTE,
+    				functionName,
+    				Strings.PARENTHESIS_OPEN,
+    				Strings.SINGLE_QUOTE,
+    				params,
+    				Strings.SINGLE_QUOTE,
+    				Strings.COMMA,
+    				Strings.THIS,
+    				Strings.PARENTHESIS_CLOSE
+    	  );
     }
 
 }

--- a/src/main/java/org/thymeleaf/dialect/springdata/util/Strings.java
+++ b/src/main/java/org/thymeleaf/dialect/springdata/util/Strings.java
@@ -11,8 +11,15 @@ public final class Strings {
     public static final String AND = "&";
     public static final String Q_MARK = "?";
     public static final String EQ = "=";
+    public static final String PARENTHESIS_OPEN = "(";
+    public static final String PARENTHESIS_CLOSE = ")";
+    public static final String SINGLE_QUOTE = "'";
+    public static final String DOUBLE_QUOTE = "\"";
+    public static final String JAVASCRIPT_VOID_0 = "javascript:void(0)";
     public static final String PAGE = "page";
     public static final String SIZE = "size";
+    public static final String THIS = "this";
+    public static final String ONCLICK = "onclick";
     public static final String SORTED_PREFIX = "sorted-";
     public static final String SORT = "sort";
 


### PR DESCRIPTION
Hey, i've added the possibility to use javascript instead of full page navigation. So you can reload the table async (e.g. with fetch api) and only replace the table on the document. In my use case, there is a table not loaded on the initial page load, so whole page reload after paging or sorting is not an option.

I also thought about using plane javascript url like href="javascript:foo()", but there is an issue with passing this/event to the function, so i use some form of "injecting" the onclick attribute.

Sorry for the fucked indentation after the push - might be caused by different ide settings.